### PR TITLE
Use executable as the first argument in _virtualenv_sys

### DIFF
--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -46,11 +46,12 @@ def _dirmatch(path, matchwith):
 def _virtualenv_sys(venv_path):
     "obtain version and path info from a virtualenv."
     executable = os.path.join(venv_path, 'bin', 'python')
-    p = subprocess.Popen(['python',
+    # Must use "executable" as the first argument rather than as the
+    # keyword argument "executable" to get correct value from sys.path
+    p = subprocess.Popen([executable,
         '-c', 'import sys;'
               'print (sys.version[:3]);'
               'print ("\\n".join(sys.path));'],
-        executable=executable,
         env={},
         stdout=subprocess.PIPE)
     stdout, err = p.communicate()


### PR DESCRIPTION
For some reason, `sys.path` only has the value that's used in the virtualenv when the first argument to subprocess.Popen is the actual path to the python executable in the virtualenv.

Before this commit, the value of `sys.path` as fetched by `_virtualenv_sys` was equal to the value that would be fetched by using the default python interpreter (as if you just used `python` outside of the virtualenv).

Tested on Python 2.7.3 as shipped with Ubuntu 12.04 LTS.
