### PR TITLE
Fix symlinks that point to the old virtual env

### DIFF
--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import with_statement
 import logging
 import optparse
@@ -7,7 +8,7 @@ import shutil
 import subprocess
 import sys
 
-version_info = (0, 2, 4)
+version_info = (0, 2, 6)
 __version__ = '.'.join(map(str, version_info))
 
 
@@ -267,6 +268,7 @@ def main():
     try:
         old_dir, new_dir = args
     except ValueError:
+        print("virtualenv-close {}".format(__version__))
         parser.error("not enough arguments given.")
     old_dir = os.path.normpath(os.path.abspath(old_dir))
     new_dir = os.path.normpath(os.path.abspath(new_dir))


### PR DESCRIPTION
First of all, congrats for the nice tool. It saves us a lot of time!

Sometimes the source virtual environment has symlinks that point to itself

the issue I had were:

$OLD_VIRTUAL_ENV/local/lib points to $OLD_VIRTUAL_ENV/lib 
$OLD_VIRTUAL_ENV/local/bin points to $OLD_VIRTUAL_ENV/bin

which was causing pip to complain about updating the packages because they were out of the virtual environment.

this pull request makes sure
$NEW_VIRTUAL_ENV/local/lib will point to $NEW_VIRTUAL_ENV/lib


I also took the liberty to bump the version to 0.2.6

if possible, please release a new version on pypy because this would make our life easier.
 