### PR TITLE
Eliminate symbolic links

### DIFF
--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -291,8 +291,8 @@ def main():
     except ValueError:
         print("virtualenv-clone {}".format(__version__))
         parser.error("not enough arguments given.")
-    old_dir = os.path.normpath(os.path.abspath(old_dir))
-    new_dir = os.path.normpath(os.path.abspath(new_dir))
+    old_dir = os.path.realpath(os.path.normpath(os.path.abspath(old_dir)))
+    new_dir = os.path.realpath(os.path.normpath(os.path.abspath(new_dir)))
     loglevel = (logging.WARNING, logging.INFO, logging.DEBUG)[min(2,
             options.verbose)]
     logging.basicConfig(level=loglevel, format='%(message)s')

--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -291,8 +291,8 @@ def main():
     except ValueError:
         print("virtualenv-clone {}".format(__version__))
         parser.error("not enough arguments given.")
-    old_dir = os.path.realpath(os.path.normpath(os.path.abspath(old_dir)))
-    new_dir = os.path.realpath(os.path.normpath(os.path.abspath(new_dir)))
+    old_dir = os.path.realpath(old_dir)
+    new_dir = os.path.realpath(new_dir)
     loglevel = (logging.WARNING, logging.INFO, logging.DEBUG)[min(2,
             options.verbose)]
     logging.basicConfig(level=loglevel, format='%(message)s')


### PR DESCRIPTION
This removes any references to symbolic links when cloning. We were seeing a bug due to this in our deploy process. For example, suppose `current` is the symlink to the current release deployed.

```
release1 -> current
release2

virtualenv-clone current/python_env release2/python_env
```

`old_dir` will be `current/python_env` but in actuality the proper old path is `release1/python_env` and thus the find and replace fails 
