### PR TITLE
Match with source venv python version as well.

### DIFF
--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -170,6 +170,11 @@ def fixup_script_(root, file_, old_dir, new_dir, version,
         # binary file
         return
 
+    # This takes care of the scheme in which shebang is of type
+    # '#!/venv/bin/python3' while the version of system python
+    # is of type 3.x e.g. 3.5.
+    short_version = bang[len(old_shebang):]
+
     if not bang.startswith('#!'):
         return
     elif bang == old_shebang:
@@ -177,6 +182,10 @@ def fixup_script_(root, file_, old_dir, new_dir, version,
     elif (bang.startswith(old_shebang)
           and bang[len(old_shebang):] == version):
         rewrite_shebang(version)
+    elif (bang.startswith(old_shebang)
+          and short_version
+          and bang[len(old_shebang):] == short_version):
+        rewrite_shebang(short_version)
     elif rewrite_env_python and bang.startswith(env_shebang):
         if bang == env_shebang:
             rewrite_shebang()

--- a/tests/test_fixup_scripts.py
+++ b/tests/test_fixup_scripts.py
@@ -152,3 +152,38 @@ if __name__ == '__main__':
         assert clone_path in data
 
         assert clone_path + '/bin/python2.7' in data
+
+    def test_fixup_script_different_version(self):
+        '''Verify if version is updated'''
+
+        script = '''#!%s/bin/python2
+# EASY-INSTALL-ENTRY-SCRIPT: 'console_scripts'
+import sys
+
+if __name__ == '__main__':
+    print('Testing VirtualEnv-Clone!')
+    sys.exit()''' % venv_path
+
+        # want to do this manually,
+        # so going to call clone before the file exists
+        # run virtualenv-clone
+        sys.argv = ['virtualenv-clone', venv_path, clone_path]
+        clonevirtualenv.main()
+
+        root = os.path.join(clone_path, 'bin')
+        new_ = os.path.join(clone_path, 'bin', 'clonetest')
+        # write the file straight to the cloned
+        with open(new_, 'w') as f:
+            f.write(script)
+
+        # run fixup
+        clonevirtualenv.fixup_script_(root,
+            'clonetest', venv_path, clone_path, '2.7')
+
+        with open(new_, 'r') as f:
+            data = f.read()
+
+        assert venv_path not in data
+        assert clone_path in data
+
+        assert clone_path + '/bin/python2' in data


### PR DESCRIPTION
This takes care of the scheme in which shebang is of type
is of type 3.x e.g. 3.5.

Fixes: #23 

@edwardgeorge, can you please review? Thanks.
