### PR TITLE
Add Python 3.6, drop support for EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   -   "2.7"
-  -   "3.3"
   -   "3.4"
   -   "3.5"
+  -   "3.6"
 install:
   -   pip install pytest virtualenv
 script:

--- a/README
+++ b/README
@@ -30,4 +30,4 @@ It performs the following:
 - finally it double checks sys.path again and will fail if there are still
   paths from the old environment present.
 
-NOTE: This script requires Python >= 2.5
+NOTE: This script requires Python 2.7 or 3.4+

--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -18,10 +18,6 @@ __version__ = '.'.join(map(str, version_info))
 logger = logging.getLogger()
 
 
-if sys.version_info < (2, 6):
-    next = lambda gen: gen.next()
-
-
 env_bin_dir = 'bin'
 if sys.platform == 'win32':
     env_bin_dir = 'Scripts'

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools.command.test import test as TestCommand
 from setuptools import setup
 
 
-if __name__ == '__main__' and sys.version_info < (2, 5):
-    raise SystemExit("Python >= 2.5 required for virtualenv-clone")
+if __name__ == '__main__' and sys.version_info < (2, 7):
+    raise SystemExit("Python >= 2.7 required for virtualenv-clone")
 
 test_requirements = [
     'virtualenv',
@@ -36,14 +36,15 @@ setup(name="virtualenv-clone",
         'console_scripts': [
             'virtualenv-clone=clonevirtualenv:main',
     ]},
-    classifiers=[
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+      classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Intended Audience :: Developers",
         "Development Status :: 3 - Alpha",
-        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+envlist = py27,py34,py35,py36
 
 [testenv]
 commands = py.test -v []


### PR DESCRIPTION
Python 2.5-2.6 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
-- | -- | --
2.5 | 2006-09-19 | 2011-05-26
2.6 | 2008-10-01 | 2013-10-29
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29

They're also little used. Here are its PyPI downloads for last month:

| category | percent | downloads |
|----------|--------:|----------:|
|      3.6 |  35.84% |   252,944 |
|      2.7 |  33.30% |   235,031 |
|      3.5 |  18.91% |   133,480 |
|      3.7 |  10.06% |    70,965 |
|      3.4 |   1.58% |    11,154 |
| null     |   0.19% |     1,345 |
|      2.6 |   0.08% |       594 |
|      3.3 |   0.02% |       147 |
|      3.8 |   0.01% |        45 |
|      3.2 |   0.00% |        11 |
|      3.1 |   0.00% |         1 |
| Total    |         |   705,717 |

Further:

* 2.5 and 2.6 are not tested on the CI, so it's quite possible it doesn't work on those.

* 3.3 is now broken on master on the CI due to dependencies no longer supporting it: https://travis-ci.org/hugovk/virtualenv-clone/builds/435578978

* The test requirements `virtualenv`, `tox` and `pytest` have already dropped <=2.6 and 3.0-3.3.
