### PR TITLE
Must convert iterable to list to reuse in Python 3

### DIFF
--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -61,7 +61,7 @@ def _virtualenv_sys(venv_path):
     stdout, err = p.communicate()
     assert not p.returncode and stdout
     lines = stdout.decode('utf-8').splitlines()
-    return lines[0], filter(bool, lines[1:])
+    return lines[0], list(filter(bool, lines[1:]))
 
 
 def clone_virtualenv(src_dir, dst_dir):

--- a/tests/test_virtualenv_sys.py
+++ b/tests/test_virtualenv_sys.py
@@ -75,6 +75,7 @@ class TestVirtualenvSys(TestCase):
             clonevirtualenv.main()
 
             sys_path = clonevirtualenv._virtualenv_sys(clone_path)[1]
+            assert isinstance(sys_path, list), "Path information needs to be a list"
 
             paths = [path for path in sys_path]
             assert paths, "There should be path information"


### PR DESCRIPTION
This pull request addresses issue #48 that is encountered when there are pth files and other such sys.path impacting things in Python 3 environments.