### PR TITLE
Fix typo about suffix (extension) of README file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README
+include README.md
 include LICENSE


### PR DESCRIPTION
Add missing .md suffix to README file