### PR TITLE
If the clone fails, it should throw an error

### DIFF
--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -197,9 +197,14 @@ def fixup_activate(filename, old_dir, new_dir):
     with open(filename, 'rb') as f:
         data = f.read().decode('utf-8')
 
-    data = data.replace(old_dir, new_dir)
+    # search/replace the directory path in the activate script
+    new_data = data.replace(old_dir, new_dir)
+    if new_data == data:
+        raise UserError("The activate script did not contain the "
+                        "old directory {0}".format(old_dir))
+
     with open(filename, 'wb') as f:
-        f.write(data.encode('utf-8'))
+        f.write(new_data.encode('utf-8'))
 
 
 def fixup_link(filename, old_dir, new_dir, target=None):

--- a/clonevirtualenv.py
+++ b/clonevirtualenv.py
@@ -197,14 +197,14 @@ def fixup_activate(filename, old_dir, new_dir):
     with open(filename, 'rb') as f:
         data = f.read().decode('utf-8')
 
-    # search/replace the directory path in the activate script
-    new_data = data.replace(old_dir, new_dir)
-    if new_data == data:
+    # verify that the clone is even possible
+    if not old_dir in data:
         raise UserError("The activate script did not contain the "
                         "old directory {0}".format(old_dir))
 
+    data = data.replace(old_dir, new_dir)
     with open(filename, 'wb') as f:
-        f.write(new_data.encode('utf-8'))
+        f.write(data.encode('utf-8'))
 
 
 def fixup_link(filename, old_dir, new_dir, target=None):


### PR DESCRIPTION
If you do an OS-level "mv" of a virtualenv folder, the resultant virtualenv is incomplete/broken because things like the "activate" script are not updated.   If you then "virtualenv-clone" the moved virtualenv, the clone fails silently.

Due to the original virtualenv being moved (via softlink by a deployment system), my team lost a couple hours of work the other day. The virtualenv-clone failed to update the paths in the "activate" script, but it failed to do so silently, and our system lurched into a bad state. But the resultant behavior was so close to correct it took a while try track down the root cause.

Here is a working example of the current virtualenv-clone silent failure:

```shell
$ mkdir original
$ virtualenv --no-site-packages --python=python3.6 original/try1
Running virtualenv...done.
$ source original/try1/bin/activate
(try1) $ pip install graphviz==0.10.0
...
(try1) $ pip freeze
graphviz==0.10
pkg-resources==0.0.0
(try1) $ deactivate
$ mv original new
$ mkdir newest
$ virtualenv-clone new/try1 newest/try2
$ source newest/try2/bin/activate
(try1) $ pip freeze
adium-theme-ubuntu==0.3.4
arrow==0.12.1
backports.functools-lru-cache==1.5
click==6.7
Flask==1.0.2
graphviz==0.10.1
...
```

What happened here is the virtualenv-clone failed, but threw no errors. So the virtualenv that opened up is whatever happened to be the system-wide Python install. At this point, madness ensues.

Okay, let's try the above process with the updated version of virtualenv-clone in this Pull Request:

```shell
$ mkdir original
$ virtualenv --no-site-packages --python=python3.6 original/try1
Running virtualenv...done.
$ source original/try1/bin/activate
(try1) $ pip install graphviz==0.10.0
...
(try1) $ pip freeze
graphviz==0.10
pkg-resources==0.0.0
(try1) $ deactivate
$ mv original new
$ mkdir newest
$ virtualenv-clone new/try1 newest/try2
Usage: clonevirtualenv.py [options] /path/to/existing/venv /path/to/cloned/venv

clonevirtualenv.py: error: The activate script did not contain the old directory /home/jstilley/Desktop/new/try1
```

Perfect!  An error is thrown.  Nothing is hidden.