### PR TITLE
fix: skip `my-test-package.zip` file in `test_clone_contents`

### DIFF
--- a/tests/test_virtualenv_clone.py
+++ b/tests/test_virtualenv_clone.py
@@ -54,6 +54,7 @@ class TestVirtualenvClone(TestBase):
                 if file_.endswith('.pyc') or\
                     file_.endswith('.exe') or\
                     file_.endswith('.egg') or\
+                    file_.endswith('.zip') or\
                     file_ in ['python', 'python%s' % version]:
                     # binarys fail reading and
                     # compiled will be recompiled


### PR DESCRIPTION
  - With virtualenv version >= 20.13.0, the `test_clone_contents` started failing, because a zip file was present within the cloned virtualenv directory and couldn't be decoded as 'utf-8'.

  - Users saw the following error when running tests:

    ``` File "virtualenv-clone/tests/test_virtualenv_clone.py", line 75, in test_clone_contents lines = f.read().decode('utf-8') UnicodeDecodeError: 'utf-8' codec can't decode byte 0xba in position 10: invalid start byte ```
  - The zip file, `my-test-package.zip`, is probably created because of the inclusion of the `my-test-package` with newer versions of setuptools. https://github.com/pypa/setuptools/issues/2709

  - This commit simply updates the test to skip over `.zip` files, like it already does for other types of binary files (`.pyc`, '.egg` etc.)